### PR TITLE
Fix config page property mismatch

### DIFF
--- a/package/contents/ui/configGeneral.qml
+++ b/package/contents/ui/configGeneral.qml
@@ -14,6 +14,13 @@ KCM.SimpleKCM {
     property alias kcfg_fadeEnabled: fadeEnabledCheckBox.checked
     property alias kcfg_preferredWidth: preferredWidthSpinBox.value
 
+    // cfg_* aliases satisfy generic config pages like ConfigurationShortcuts
+    property alias cfg_rssUrl: rssUrlField.text
+    property alias cfg_updateInterval: updateIntervalSpinBox.value
+    property alias cfg_scrollSpeed: scrollSpeedSpinBox.value
+    property alias cfg_fadeEnabled: fadeEnabledCheckBox.checked
+    property alias cfg_preferredWidth: preferredWidthSpinBox.value
+
     Kirigami.FormLayout {
         QQC2.TextField {
             id: rssUrlField


### PR DESCRIPTION
## Summary
- expose `cfg_*` properties in config page

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6863cbae46608330a505ac917d2123a4